### PR TITLE
Add simple web UI for robot control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Web UI
+Launch the simple control page:
+
+    rosrun webui webui_node.py
+
+Access http://<IP>:5000/ from your network browser to control the real robot or Gazebo.
+
 # This file currently only serves to mark the location of a catkin workspace for tool integration
 ros 下机器人工作空间：roboarm3_ws： 中
 文件夹（1）build和devel由编译生成

--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(webui)
+
+find_package(catkin REQUIRED COMPONENTS rospy geometry_msgs)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS scripts/webui_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/src/webui/package.xml
+++ b/src/webui/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>webui</name>
+  <version>0.0.1</version>
+  <description>Simple web interface to control robot via HTTP.</description>
+  <maintainer email="user@example.com">Your Name</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>rospy</depend>
+  <depend>geometry_msgs</depend>
+  <exec_depend>python3-flask</exec_depend>
+</package>

--- a/src/webui/scripts/webui_node.py
+++ b/src/webui/scripts/webui_node.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import rospy
+from geometry_msgs.msg import Twist
+from flask import Flask, request, redirect
+
+app = Flask(__name__)
+
+real_pub = None
+sim_pub = None
+
+@app.route('/')
+def index():
+    return (
+        '<h1>Robot Control</h1>'
+        '<h2>Real Robot</h2>'
+        '<form action="/move/real" method="post">'
+        '<button name="action" value="forward">Forward</button>'
+        '<button name="action" value="back">Back</button>'
+        '<button name="action" value="left">Left</button>'
+        '<button name="action" value="right">Right</button>'
+        '<button name="action" value="stop">Stop</button>'
+        '</form>'
+        '<h2>Gazebo</h2>'
+        '<form action="/move/sim" method="post">'
+        '<button name="action" value="forward">Forward</button>'
+        '<button name="action" value="back">Back</button>'
+        '<button name="action" value="left">Left</button>'
+        '<button name="action" value="right">Right</button>'
+        '<button name="action" value="stop">Stop</button>'
+        '</form>'
+    )
+
+@app.route('/move/<target>', methods=['POST'])
+def move(target):
+    action = request.form.get('action', 'stop')
+    twist = Twist()
+    speed = 0.5
+    turn = 1.0
+    if action == 'forward':
+        twist.linear.x = speed
+    elif action == 'back':
+        twist.linear.x = -speed
+    elif action == 'left':
+        twist.angular.z = turn
+    elif action == 'right':
+        twist.angular.z = -turn
+    # else stop
+    if target == 'real':
+        real_pub.publish(twist)
+    else:
+        sim_pub.publish(twist)
+    return redirect('/')
+
+def main():
+    global real_pub, sim_pub
+    rospy.init_node('webui_node')
+    real_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
+    sim_pub = rospy.Publisher('/gazebo/cmd_vel', Twist, queue_size=1)
+    app.run(host='0.0.0.0', port=5000, debug=False)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `webui` package with a Flask-based page for basic robot control
- expose endpoints to drive the real robot or Gazebo via `/cmd_vel`
- document how to launch the web UI

## Testing
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*
- `catkin_make` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b5afc2b08329b45690059ac1bbde