### PR TITLE
Add web UI for robot control with Cartesian pose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Access `http://<IP>:5000/` from your network browser. The page offers
 buttons labelled X±/Y±/Z± that increment the target position along each
 axis for both the real robot and the Gazebo simulation.
 
+Run the MoveIt subscriber so the arm follows the commands:
+
+    rosrun webui pose_listener.py
+
 # This file currently only serves to mark the location of a catkin workspace for tool integration
 ros 下机器人工作空间：roboarm3_ws： 中
 文件夹（1）build和devel由编译生成

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@ Launch the control page:
 
     rosrun webui webui_node.py
 
-Access `http://<IP>:5000/` from your network browser. The page provides
-buttons for basic velocity commands and forms to send Cartesian
-positions (x/y/z and roll/pitch/yaw) for both the real robot and the
-Gazebo simulation. The simulation section now publishes to the standard
-`/cmd_vel` topic so the virtual robot responds to web commands.
+Access `http://<IP>:5000/` from your network browser. The page offers
+buttons labelled X±/Y±/Z± that increment the target position along each
+axis for both the real robot and the Gazebo simulation.
 
 # This file currently only serves to mark the location of a catkin workspace for tool integration
 ros 下机器人工作空间：roboarm3_ws： 中

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## Web UI
+Launch the control page:
+
+    rosrun webui webui_node.py
+
+Access `http://<IP>:5000/` from your network browser. The page provides
+buttons for basic velocity commands and forms to send Cartesian
+positions (x/y/z and roll/pitch/yaw) for both the real robot and the
+Gazebo simulation. The simulation section now publishes to the standard
+`/cmd_vel` topic so the virtual robot responds to web commands.
+
 # This file currently only serves to mark the location of a catkin workspace for tool integration
 ros 下机器人工作空间：roboarm3_ws： 中
 文件夹（1）build和devel由编译生成

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ axis for both the real robot and the Gazebo simulation.
 
 Run the MoveIt subscriber so the arm follows the commands:
 
-    rosrun webui pose_listener.py
+    rosrun webui pose_listener.py [_move_group:=<group_name>]
+
+By default the node uses the `manipulator` MoveIt planning group. If your
+robot uses a different group name, set the `~move_group` parameter as shown
+above.
 
 # This file currently only serves to mark the location of a catkin workspace for tool integration
 ros 下机器人工作空间：roboarm3_ws： 中

--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -5,5 +5,5 @@ find_package(catkin REQUIRED COMPONENTS rospy geometry_msgs)
 
 catkin_package()
 
-catkin_install_python(PROGRAMS scripts/webui_node.py
+catkin_install_python(PROGRAMS scripts/webui_node.py scripts/pose_listener.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(webui)
+
+find_package(catkin REQUIRED COMPONENTS rospy geometry_msgs tf)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS scripts/webui_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(webui)
 
-find_package(catkin REQUIRED COMPONENTS rospy geometry_msgs tf)
+find_package(catkin REQUIRED COMPONENTS rospy geometry_msgs)
 
 catkin_package()
 

--- a/src/webui/package.xml
+++ b/src/webui/package.xml
@@ -8,6 +8,5 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>rospy</depend>
   <depend>geometry_msgs</depend>
-  <depend>tf</depend>
   <exec_depend>python3-flask</exec_depend>
 </package>

--- a/src/webui/package.xml
+++ b/src/webui/package.xml
@@ -9,4 +9,5 @@
   <depend>rospy</depend>
   <depend>geometry_msgs</depend>
   <exec_depend>python3-flask</exec_depend>
+  <exec_depend>moveit_commander</exec_depend>
 </package>

--- a/src/webui/package.xml
+++ b/src/webui/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>webui</name>
+  <version>0.0.1</version>
+  <description>Simple web interface to control robot via HTTP.</description>
+  <maintainer email="user@example.com">Your Name</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>rospy</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf</depend>
+  <exec_depend>python3-flask</exec_depend>
+</package>

--- a/src/webui/scripts/pose_listener.py
+++ b/src/webui/scripts/pose_listener.py
@@ -9,7 +9,12 @@ import moveit_commander
 class PoseListener:
     def __init__(self):
         moveit_commander.roscpp_initialize([])
-        self.group = moveit_commander.MoveGroupCommander('manipulator')
+        group_name = rospy.get_param('~move_group', 'manipulator')
+        try:
+            self.group = moveit_commander.MoveGroupCommander(group_name)
+        except RuntimeError as exc:
+            rospy.logfatal("Planning group '%s' not found: %s", group_name, exc)
+            raise
         rospy.Subscriber('/target_pose', PoseStamped, self._cb)
         rospy.Subscriber('/gazebo/target_pose', PoseStamped, self._cb)
 

--- a/src/webui/scripts/pose_listener.py
+++ b/src/webui/scripts/pose_listener.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Subscribe to target_pose topics and execute motions with MoveIt."""
+
+import rospy
+from geometry_msgs.msg import PoseStamped
+import moveit_commander
+
+
+class PoseListener:
+    def __init__(self):
+        moveit_commander.roscpp_initialize([])
+        self.group = moveit_commander.MoveGroupCommander('manipulator')
+        rospy.Subscriber('/target_pose', PoseStamped, self._cb)
+        rospy.Subscriber('/gazebo/target_pose', PoseStamped, self._cb)
+
+    def _cb(self, msg: PoseStamped):
+        self.group.set_pose_target(msg.pose)
+        self.group.go(wait=True)
+        self.group.stop()
+        self.group.clear_pose_targets()
+
+
+def main():
+    rospy.init_node('pose_listener')
+    listener = PoseListener()
+    rospy.spin()
+    moveit_commander.roscpp_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/webui/scripts/webui_node.py
+++ b/src/webui/scripts/webui_node.py
@@ -1,110 +1,79 @@
 #!/usr/bin/env python3
+"""Simple Flask interface with buttons to move in x/y/z."""
+
 import rospy
-from geometry_msgs.msg import Twist, PoseStamped
+from geometry_msgs.msg import PoseStamped
 from flask import Flask, request, redirect
-from tf.transformations import quaternion_from_euler
 
 app = Flask(__name__)
 
-real_pub = None
-sim_pub = None
+# Publishers for real robot and Gazebo
 real_pose_pub = None
 sim_pose_pub = None
+
+# Current poses so each button press offsets from the last command
+real_pose = PoseStamped()
+real_pose.pose.orientation.w = 1.0
+sim_pose = PoseStamped()
+sim_pose.pose.orientation.w = 1.0
+
 
 @app.route('/')
 def index():
     return (
         '<h1>Robot Control</h1>'
         '<h2>Real Robot</h2>'
-        '<form action="/move/real" method="post">'
-        '<button name="action" value="forward">Forward</button>'
-        '<button name="action" value="back">Back</button>'
-        '<button name="action" value="left">Left</button>'
-        '<button name="action" value="right">Right</button>'
-        '<button name="action" value="stop">Stop</button>'
-        '</form>'
-        '<form action="/pose/real" method="post">'
-        'X:<input name="x" type="number" step="0.01">'
-        'Y:<input name="y" type="number" step="0.01">'
-        'Z:<input name="z" type="number" step="0.01">'
-        'Roll:<input name="roll" type="number" step="0.01">'
-        'Pitch:<input name="pitch" type="number" step="0.01">'
-        'Yaw:<input name="yaw" type="number" step="0.01">'
-        '<button type="submit">Send Pose</button>'
+        '<form action="/step/real" method="post">'
+        '<button name="axis" value="x+">X+</button>'
+        '<button name="axis" value="x-">X-</button>'
+        '<button name="axis" value="y+">Y+</button>'
+        '<button name="axis" value="y-">Y-</button>'
+        '<button name="axis" value="z+">Z+</button>'
+        '<button name="axis" value="z-">Z-</button>'
         '</form>'
         '<h2>Gazebo</h2>'
-        '<form action="/move/sim" method="post">'
-        '<button name="action" value="forward">Forward</button>'
-        '<button name="action" value="back">Back</button>'
-        '<button name="action" value="left">Left</button>'
-        '<button name="action" value="right">Right</button>'
-        '<button name="action" value="stop">Stop</button>'
-        '</form>'
-        '<form action="/pose/sim" method="post">'
-        'X:<input name="x" type="number" step="0.01">'
-        'Y:<input name="y" type="number" step="0.01">'
-        'Z:<input name="z" type="number" step="0.01">'
-        'Roll:<input name="roll" type="number" step="0.01">'
-        'Pitch:<input name="pitch" type="number" step="0.01">'
-        'Yaw:<input name="yaw" type="number" step="0.01">'
-        '<button type="submit">Send Pose</button>'
+        '<form action="/step/sim" method="post">'
+        '<button name="axis" value="x+">X+</button>'
+        '<button name="axis" value="x-">X-</button>'
+        '<button name="axis" value="y+">Y+</button>'
+        '<button name="axis" value="y-">Y-</button>'
+        '<button name="axis" value="z+">Z+</button>'
+        '<button name="axis" value="z-">Z-</button>'
         '</form>'
     )
 
-@app.route('/move/<target>', methods=['POST'])
-def move(target):
-    action = request.form.get('action', 'stop')
-    twist = Twist()
-    speed = 0.5
-    turn = 1.0
-    if action == 'forward':
-        twist.linear.x = speed
-    elif action == 'back':
-        twist.linear.x = -speed
-    elif action == 'left':
-        twist.angular.z = turn
-    elif action == 'right':
-        twist.angular.z = -turn
-    # else stop
-    if target == 'real':
-        real_pub.publish(twist)
-    else:
-        sim_pub.publish(twist)
+
+@app.route('/step/<target>', methods=['POST'])
+def step(target):
+    axis = request.form.get('axis', '')
+    step = 0.1
+    pose = real_pose if target == 'real' else sim_pose
+    if axis == 'x+':
+        pose.pose.position.x += step
+    elif axis == 'x-':
+        pose.pose.position.x -= step
+    elif axis == 'y+':
+        pose.pose.position.y += step
+    elif axis == 'y-':
+        pose.pose.position.y -= step
+    elif axis == 'z+':
+        pose.pose.position.z += step
+    elif axis == 'z-':
+        pose.pose.position.z -= step
+    pose.header.stamp = rospy.Time.now()
+    pub = real_pose_pub if target == 'real' else sim_pose_pub
+    pub.publish(pose)
     return redirect('/')
 
-
-@app.route('/pose/<target>', methods=['POST'])
-def pose(target):
-    x = float(request.form.get('x', 0))
-    y = float(request.form.get('y', 0))
-    z = float(request.form.get('z', 0))
-    roll = float(request.form.get('roll', 0))
-    pitch = float(request.form.get('pitch', 0))
-    yaw = float(request.form.get('yaw', 0))
-    qx, qy, qz, qw = quaternion_from_euler(roll, pitch, yaw)
-    msg = PoseStamped()
-    msg.header.stamp = rospy.Time.now()
-    msg.pose.position.x = x
-    msg.pose.position.y = y
-    msg.pose.position.z = z
-    msg.pose.orientation.x = qx
-    msg.pose.orientation.y = qy
-    msg.pose.orientation.z = qz
-    msg.pose.orientation.w = qw
-    if target == 'real':
-        real_pose_pub.publish(msg)
-    else:
-        sim_pose_pub.publish(msg)
-    return redirect('/')
 
 def main():
-    global real_pub, sim_pub, real_pose_pub, sim_pose_pub
+    global real_pose_pub, sim_pose_pub
     rospy.init_node('webui_node')
-    real_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
-    sim_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
     real_pose_pub = rospy.Publisher('/target_pose', PoseStamped, queue_size=1)
     sim_pose_pub = rospy.Publisher('/gazebo/target_pose', PoseStamped, queue_size=1)
     app.run(host='0.0.0.0', port=5000, debug=False)
 
+
 if __name__ == '__main__':
     main()
+

--- a/src/webui/scripts/webui_node.py
+++ b/src/webui/scripts/webui_node.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+import rospy
+from geometry_msgs.msg import Twist, PoseStamped
+from flask import Flask, request, redirect
+from tf.transformations import quaternion_from_euler
+
+app = Flask(__name__)
+
+real_pub = None
+sim_pub = None
+real_pose_pub = None
+sim_pose_pub = None
+
+@app.route('/')
+def index():
+    return (
+        '<h1>Robot Control</h1>'
+        '<h2>Real Robot</h2>'
+        '<form action="/move/real" method="post">'
+        '<button name="action" value="forward">Forward</button>'
+        '<button name="action" value="back">Back</button>'
+        '<button name="action" value="left">Left</button>'
+        '<button name="action" value="right">Right</button>'
+        '<button name="action" value="stop">Stop</button>'
+        '</form>'
+        '<form action="/pose/real" method="post">'
+        'X:<input name="x" type="number" step="0.01">'
+        'Y:<input name="y" type="number" step="0.01">'
+        'Z:<input name="z" type="number" step="0.01">'
+        'Roll:<input name="roll" type="number" step="0.01">'
+        'Pitch:<input name="pitch" type="number" step="0.01">'
+        'Yaw:<input name="yaw" type="number" step="0.01">'
+        '<button type="submit">Send Pose</button>'
+        '</form>'
+        '<h2>Gazebo</h2>'
+        '<form action="/move/sim" method="post">'
+        '<button name="action" value="forward">Forward</button>'
+        '<button name="action" value="back">Back</button>'
+        '<button name="action" value="left">Left</button>'
+        '<button name="action" value="right">Right</button>'
+        '<button name="action" value="stop">Stop</button>'
+        '</form>'
+        '<form action="/pose/sim" method="post">'
+        'X:<input name="x" type="number" step="0.01">'
+        'Y:<input name="y" type="number" step="0.01">'
+        'Z:<input name="z" type="number" step="0.01">'
+        'Roll:<input name="roll" type="number" step="0.01">'
+        'Pitch:<input name="pitch" type="number" step="0.01">'
+        'Yaw:<input name="yaw" type="number" step="0.01">'
+        '<button type="submit">Send Pose</button>'
+        '</form>'
+    )
+
+@app.route('/move/<target>', methods=['POST'])
+def move(target):
+    action = request.form.get('action', 'stop')
+    twist = Twist()
+    speed = 0.5
+    turn = 1.0
+    if action == 'forward':
+        twist.linear.x = speed
+    elif action == 'back':
+        twist.linear.x = -speed
+    elif action == 'left':
+        twist.angular.z = turn
+    elif action == 'right':
+        twist.angular.z = -turn
+    # else stop
+    if target == 'real':
+        real_pub.publish(twist)
+    else:
+        sim_pub.publish(twist)
+    return redirect('/')
+
+
+@app.route('/pose/<target>', methods=['POST'])
+def pose(target):
+    x = float(request.form.get('x', 0))
+    y = float(request.form.get('y', 0))
+    z = float(request.form.get('z', 0))
+    roll = float(request.form.get('roll', 0))
+    pitch = float(request.form.get('pitch', 0))
+    yaw = float(request.form.get('yaw', 0))
+    qx, qy, qz, qw = quaternion_from_euler(roll, pitch, yaw)
+    msg = PoseStamped()
+    msg.header.stamp = rospy.Time.now()
+    msg.pose.position.x = x
+    msg.pose.position.y = y
+    msg.pose.position.z = z
+    msg.pose.orientation.x = qx
+    msg.pose.orientation.y = qy
+    msg.pose.orientation.z = qz
+    msg.pose.orientation.w = qw
+    if target == 'real':
+        real_pose_pub.publish(msg)
+    else:
+        sim_pose_pub.publish(msg)
+    return redirect('/')
+
+def main():
+    global real_pub, sim_pub, real_pose_pub, sim_pose_pub
+    rospy.init_node('webui_node')
+    real_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
+    sim_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=1)
+    real_pose_pub = rospy.Publisher('/target_pose', PoseStamped, queue_size=1)
+    sim_pose_pub = rospy.Publisher('/gazebo/target_pose', PoseStamped, queue_size=1)
+    app.run(host='0.0.0.0', port=5000, debug=False)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- expand Flask page with forms to send Cartesian pose (x, y, z, roll, pitch, yaw)
- publish target pose topics for real robot and Gazebo and fix simulation velocity topic
- document how to use the enhanced web interface

## Testing
- `python -m py_compile src/webui/scripts/webui_node.py`
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b5afc2b08329b45690059ac1bbde