### PR TITLE
Add web UI for robot control with axis step buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ Launch the control page:
 
     rosrun webui webui_node.py
 
-Access `http://<IP>:5000/` from your network browser. The page offers
-buttons labelled X±/Y±/Z± that increment the target position along each
-axis for both the real robot and the Gazebo simulation.
+Access `http://<IP>:5000/` from your network browser.  Each button
+uses JavaScript to send an asynchronous request so the page no longer
+reloads or times out.  The X±/Y±/Z± buttons increment the target
+position along each axis for both the real robot and the Gazebo
+simulation.
 
 Run the MoveIt subscriber so the arm follows the commands:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+## Web UI
+Launch the control page:
+
+    rosrun webui webui_node.py
+
+Access `http://<IP>:5000/` from your network browser. The page offers
+buttons labelled X±/Y±/Z± that increment the target position along each
+axis for both the real robot and the Gazebo simulation.
+
+Run the MoveIt subscriber so the arm follows the commands:
+
+    rosrun webui pose_listener.py [_move_group:=<group_name>]
+
+The node defaults to the `arm` MoveIt planning group used in this workspace.
+If your robot uses a different group name, set the `~move_group` parameter as
+shown above.
+
 # This file currently only serves to mark the location of a catkin workspace for tool integration
 ros 下机器人工作空间：roboarm3_ws： 中
 文件夹（1）build和devel由编译生成

--- a/src/webui/CMakeLists.txt
+++ b/src/webui/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(webui)
+
+find_package(catkin REQUIRED COMPONENTS rospy geometry_msgs)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS scripts/webui_node.py scripts/pose_listener.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/src/webui/package.xml
+++ b/src/webui/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>webui</name>
+  <version>0.0.1</version>
+  <description>Simple web interface to control robot via HTTP.</description>
+  <maintainer email="user@example.com">Your Name</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>rospy</depend>
+  <depend>geometry_msgs</depend>
+  <exec_depend>python3-flask</exec_depend>
+  <exec_depend>moveit_commander</exec_depend>
+</package>

--- a/src/webui/scripts/pose_listener.py
+++ b/src/webui/scripts/pose_listener.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Subscribe to target_pose topics and execute motions with MoveIt."""
+
+import rospy
+from geometry_msgs.msg import PoseStamped
+import moveit_commander
+
+
+class PoseListener:
+    def __init__(self):
+        moveit_commander.roscpp_initialize([])
+        group_name = rospy.get_param('~move_group', 'arm')
+        try:
+            self.group = moveit_commander.MoveGroupCommander(group_name)
+        except RuntimeError as exc:
+            rospy.logfatal("Planning group '%s' not found: %s", group_name, exc)
+            raise
+        rospy.Subscriber('/target_pose', PoseStamped, self._cb)
+        rospy.Subscriber('/gazebo/target_pose', PoseStamped, self._cb)
+
+    def _cb(self, msg: PoseStamped):
+        self.group.set_pose_target(msg.pose)
+        self.group.go(wait=True)
+        self.group.stop()
+        self.group.clear_pose_targets()
+
+
+def main():
+    rospy.init_node('pose_listener')
+    listener = PoseListener()
+    rospy.spin()
+    moveit_commander.roscpp_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/webui/scripts/webui_node.py
+++ b/src/webui/scripts/webui_node.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Simple Flask interface with buttons to move in x/y/z."""
+"""Simple Flask interface with buttons to move in x/y/z.
+
+The previous version used HTML forms and redirected back to the index
+page after every click.  Some browsers reported a timeout when waiting
+for the redirect, so the interface now uses a small piece of
+JavaScript to send POST requests in the background.  Each button press
+therefore returns immediately and the page no longer reloads."""
 
 import rospy
 from geometry_msgs.msg import PoseStamped
-from flask import Flask, request, redirect
+from flask import Flask, request
 
 app = Flask(__name__)
 
@@ -14,38 +20,41 @@ sim_pose_pub = None
 # Current poses so each button press offsets from the last command
 real_pose = PoseStamped()
 real_pose.pose.orientation.w = 1.0
+real_pose.header.frame_id = "world"
 sim_pose = PoseStamped()
 sim_pose.pose.orientation.w = 1.0
+sim_pose.header.frame_id = "world"
 
 
 @app.route('/')
 def index():
+    """Serve a minimal page with buttons that trigger JS fetch calls."""
     return (
         '<h1>Robot Control</h1>'
         '<h2>Real Robot</h2>'
-        '<form action="/step/real" method="post">'
-        '<button name="axis" value="x+">X+</button>'
-        '<button name="axis" value="x-">X-</button>'
-        '<button name="axis" value="y+">Y+</button>'
-        '<button name="axis" value="y-">Y-</button>'
-        '<button name="axis" value="z+">Z+</button>'
-        '<button name="axis" value="z-">Z-</button>'
-        '</form>'
+        '<button onclick="step(\'real\',\'x+\')">X+</button>'
+        '<button onclick="step(\'real\',\'x-\')">X-</button>'
+        '<button onclick="step(\'real\',\'y+\')">Y+</button>'
+        '<button onclick="step(\'real\',\'y-\')">Y-</button>'
+        '<button onclick="step(\'real\',\'z+\')">Z+</button>'
+        '<button onclick="step(\'real\',\'z-\')">Z-</button>'
         '<h2>Gazebo</h2>'
-        '<form action="/step/sim" method="post">'
-        '<button name="axis" value="x+">X+</button>'
-        '<button name="axis" value="x-">X-</button>'
-        '<button name="axis" value="y+">Y+</button>'
-        '<button name="axis" value="y-">Y-</button>'
-        '<button name="axis" value="z+">Z+</button>'
-        '<button name="axis" value="z-">Z-</button>'
-        '</form>'
+        '<button onclick="step(\'sim\',\'x+\')">X+</button>'
+        '<button onclick="step(\'sim\',\'x-\')">X-</button>'
+        '<button onclick="step(\'sim\',\'y+\')">Y+</button>'
+        '<button onclick="step(\'sim\',\'y-\')">Y-</button>'
+        '<button onclick="step(\'sim\',\'z+\')">Z+</button>'
+        '<button onclick="step(\'sim\',\'z-\')">Z-</button>'
+        '<script>'
+        'function step(target, axis){fetch("/step/"+target,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({axis:axis})});}'
+        '</script>'
     )
 
 
 @app.route('/step/<target>', methods=['POST'])
 def step(target):
-    axis = request.form.get('axis', '')
+    data = request.get_json(silent=True) or {}
+    axis = data.get('axis', '')
     step = 0.1
     pose = real_pose if target == 'real' else sim_pose
     if axis == 'x+':
@@ -63,7 +72,7 @@ def step(target):
     pose.header.stamp = rospy.Time.now()
     pub = real_pose_pub if target == 'real' else sim_pose_pub
     pub.publish(pose)
-    return redirect('/')
+    return "ok"
 
 
 def main():
@@ -71,7 +80,7 @@ def main():
     rospy.init_node('webui_node')
     real_pose_pub = rospy.Publisher('/target_pose', PoseStamped, queue_size=1)
     sim_pose_pub = rospy.Publisher('/gazebo/target_pose', PoseStamped, queue_size=1)
-    app.run(host='0.0.0.0', port=5000, debug=False)
+    app.run(host='0.0.0.0', port=5000, debug=False, threaded=True)
 
 
 if __name__ == '__main__':

--- a/src/webui/scripts/webui_node.py
+++ b/src/webui/scripts/webui_node.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Simple Flask interface with buttons to move in x/y/z."""
+
+import rospy
+from geometry_msgs.msg import PoseStamped
+from flask import Flask, request, redirect
+
+app = Flask(__name__)
+
+# Publishers for real robot and Gazebo
+real_pose_pub = None
+sim_pose_pub = None
+
+# Current poses so each button press offsets from the last command
+real_pose = PoseStamped()
+real_pose.pose.orientation.w = 1.0
+sim_pose = PoseStamped()
+sim_pose.pose.orientation.w = 1.0
+
+
+@app.route('/')
+def index():
+    return (
+        '<h1>Robot Control</h1>'
+        '<h2>Real Robot</h2>'
+        '<form action="/step/real" method="post">'
+        '<button name="axis" value="x+">X+</button>'
+        '<button name="axis" value="x-">X-</button>'
+        '<button name="axis" value="y+">Y+</button>'
+        '<button name="axis" value="y-">Y-</button>'
+        '<button name="axis" value="z+">Z+</button>'
+        '<button name="axis" value="z-">Z-</button>'
+        '</form>'
+        '<h2>Gazebo</h2>'
+        '<form action="/step/sim" method="post">'
+        '<button name="axis" value="x+">X+</button>'
+        '<button name="axis" value="x-">X-</button>'
+        '<button name="axis" value="y+">Y+</button>'
+        '<button name="axis" value="y-">Y-</button>'
+        '<button name="axis" value="z+">Z+</button>'
+        '<button name="axis" value="z-">Z-</button>'
+        '</form>'
+    )
+
+
+@app.route('/step/<target>', methods=['POST'])
+def step(target):
+    axis = request.form.get('axis', '')
+    step = 0.1
+    pose = real_pose if target == 'real' else sim_pose
+    if axis == 'x+':
+        pose.pose.position.x += step
+    elif axis == 'x-':
+        pose.pose.position.x -= step
+    elif axis == 'y+':
+        pose.pose.position.y += step
+    elif axis == 'y-':
+        pose.pose.position.y -= step
+    elif axis == 'z+':
+        pose.pose.position.z += step
+    elif axis == 'z-':
+        pose.pose.position.z -= step
+    pose.header.stamp = rospy.Time.now()
+    pub = real_pose_pub if target == 'real' else sim_pose_pub
+    pub.publish(pose)
+    return redirect('/')
+
+
+def main():
+    global real_pose_pub, sim_pose_pub
+    rospy.init_node('webui_node')
+    real_pose_pub = rospy.Publisher('/target_pose', PoseStamped, queue_size=1)
+    sim_pose_pub = rospy.Publisher('/gazebo/target_pose', PoseStamped, queue_size=1)
+    app.run(host='0.0.0.0', port=5000, debug=False)
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- provide Flask page with X±/Y±/Z± buttons for real robot and Gazebo
- publish incremental PoseStamped commands and drop unused tf dependency
- document how to access and use the web interface
- add MoveIt pose listener that executes PoseStamped targets from the web UI
- allow configuring the MoveIt planning group via `~move_group` parameter and default to `arm`

## Testing
- `python -m py_compile src/webui/scripts/webui_node.py src/webui/scripts/pose_listener.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7b5afc2b08329b45690059ac1bbde